### PR TITLE
게시글 목록 조회 UI 변경  -- 동적 취소

### DIFF
--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -111,7 +111,7 @@ const PostList: React.FC = () => {
     )
 
   return (
-    <Box maxWidth="1200px" mx="auto" mt={4}>
+    <Box sx={{ maxWidth: '1200px', width: '100%', mx: 'auto' }} mt={4}>
       <Box
         display="flex"
         justifyContent="space-between"


### PR DESCRIPTION
동적으로 크기를 조절했더니 게시글 제목의 길이에 크기가 옹졸해지는 문제 발생함

그래서 UI를 동적으로 변경하는 걸 취소함.
- 최소 넓이를 설정
- 한 페이지에 게시글 10개씩 보이게 설정함
- 커서를 올렸을 때 UI가 이상해진 거 수정함
- 게시글들이 게시판을 꽉 채우도록 수정함